### PR TITLE
Changed BibBase URL to https://

### DIFF
--- a/research/index.html
+++ b/research/index.html
@@ -26,7 +26,7 @@
                 <!-- /.container -->
         		<h1>Publications</h1>
 			         <!-- <script src="https://bibbase.org/show?bib=http%3A%2F%2Fdblp.dagstuhl.de%2Fpers%2Ftb2%2Fa%2FAmory%3AAlexandre_M%3D.bib&jsonp=1"></script>  -->
-                    <script src="http://bibbase.org/show?bib=https://amamory.github.io/research/Amory-Alexandre.bib&jsonp=1"></script>
+                    <script src="https://bibbase.org/show?bib=https://amamory.github.io/research/Amory-Alexandre.bib&jsonp=1"></script>
     		</div><!-- /.blurb -->
 		</div><!-- /.container -->
 	</body>


### PR DESCRIPTION
Hi Alexandre, I noticed you were using BibBase, but were using an http:// BibBase URL on a https:// page. This causes some browser to not show your publications (due to security concerns). I suggest making the suggested change and using BibBase's new https:// URL.

cheers,
Christian@BibBase
